### PR TITLE
styles: add hover effects to menu, add whitespace

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,5 @@
-import React, { useState } from "react";
-
+import React from "react";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
-import "./App.scss";
 import { AboutMe } from "./components/aboutMe/aboutMe";
 import { Header } from "./components/header/header";
 import { Home } from "./components/home/home";
@@ -9,6 +7,7 @@ import { Projects } from "./components/projects/projects";
 import { MyVideos } from "./components/myVideos/myVideos";
 import { MyPictures } from "./components/myPictures/myPictures";
 import { Resume } from "./components/resume/resume";
+import "./App.scss";
 
 function App() {
   return (

--- a/src/App.scss
+++ b/src/App.scss
@@ -12,11 +12,13 @@ html {
   background-color: $primary;
 }
 .text-page {
+  margin-top: 4em;
   h1 {
     padding: 25px 5%;
     text-align: center;
     background-color: #f4f7f6;
     margin: 0 10%;
+    border-radius: 10px 10px 0 0;
     .page-title {
       width: 100%;
       background-color: $primary;
@@ -32,14 +34,16 @@ html {
     background-color: $primary-page;
     color: $primary;
     text-align: center;
+    border-radius: 0 0 10px 10px;
   }
   .image-page {
     display: grid;
     grid-template-columns: 1fr;
     grid-gap: 4%;
-    margin: 0 10%;
-    padding: 5% 5%;
+    margin: 0 10% 5%;
+    padding: 5% 5% 15%;
     background-color: white;
+    border-radius: 0 0 10px 10px;
     img {
       width: 100%;
       height: auto;

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Nav } from "../nav/nav";
 import "./header.scss";
+
 export const Header = () => {
   let navStyles = {};
   const [active, setActive] = useState(false);

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -13,6 +13,7 @@ $accent: #f4f7f6;
     -1px 1px 0 $accent-color, 1px 1px 0 $accent-color;
   font-size: 40px;
   font-weight: 1000;
+  margin-bottom: 0.7em;
   button {
     background-color: $primary;
     border: none;
@@ -28,16 +29,7 @@ $accent: #f4f7f6;
     }
   }
 }
-nav {
-  a {
-    text-decoration: none;
-    p {
-      color: $accent-color;
-      text-align: center;
-      border-bottom: 1px solid $accent-color;
-    }
-  }
-}
+
 @media print {
   .headerMenu {
     display: none;

--- a/src/components/myPictures/myPictures.js
+++ b/src/components/myPictures/myPictures.js
@@ -1,22 +1,17 @@
 import React from "react";
-// import "./myPictures.scss";
-
-// import myPictures from "./pictures.json";
 
 export const MyPictures = () => {
   let myPictures = require("../myPictures/pics.json");
-  console.log(myPictures);
   return (
     <>
       <main className="text-page">
         <h1>
-          <p className="page-title">My Pictures</p>
+          <p className="page-title">Pictures</p>
         </h1>
         <div className="image-page">
-          {myPictures.map((item) => {
-            console.log(item);
-            return <img src={item.img} alt="error" className="picture" />;
-          })}
+          {myPictures.map((item) => (
+            <img src={item.img} alt="error" className="picture" />
+          ))}
         </div>
       </main>
     </>

--- a/src/components/myVideos/myVideos.js
+++ b/src/components/myVideos/myVideos.js
@@ -1,4 +1,4 @@
 import React from "react";
 export const MyVideos = () => {
-  return <div className="page-info">My Videos</div>;
+  return <div className="page-info">Videos</div>;
 };

--- a/src/components/nav/nav.scss
+++ b/src/components/nav/nav.scss
@@ -5,19 +5,26 @@ $primary: #253745;
 }
 nav {
   margin: 0 10%;
-
   background-color: $primary;
-
   flex-direction: column;
   border: 1px solid $accent;
   border-radius: 10px;
   a {
     text-decoration: none;
+    &:not(:last-of-type) {
+      border-bottom: 1px solid $accent;
+    }
+    &:hover {
+      background-color: $accent;
+      opacity: 0.56;
+      p {
+        color: $primary;
+      }
+    }
     p {
       color: $accent;
       text-align: center;
-      border-bottom: 1px solid $accent;
-      border-radius: 10px;
+      margin: 10px 0;
     }
   }
 }

--- a/src/components/projects/projects.js
+++ b/src/components/projects/projects.js
@@ -1,7 +1,6 @@
-import React, { useState } from "react";
+import React from "react";
 import { TodoApp } from "./todoList/TodoApp";
 import { TipCalculator } from "./tipCalculator/TipCalculator";
-// import "./projects.scss";
 
 export const Projects = () => {
   return (

--- a/src/objects/nav.json
+++ b/src/objects/nav.json
@@ -1,9 +1,9 @@
 [
   { "title": "Home", "link": "/" },
-  { "title": "About Me", "link": "/aboutMe" },
+  { "title": "About", "link": "/aboutMe" },
   { "title": "Projects", "link": "/Projects" },
-  { "title": "My Resume", "link": "/myResume" },
-  { "title": "My Videos", "link": "/myVideos" },
-  { "title": "My Pictures", "link": "/myPictures" },
+  { "title": "Resume", "link": "/myResume" },
+  { "title": "Videos", "link": "/myVideos" },
+  { "title": "Pictures", "link": "/myPictures" },
   { "title": "Contact", "link": "/contact" }
 ]


### PR DESCRIPTION
## Description

This PR adds whitespace to the overall page component, and adds a hover effect to the navigation.

## Changes
* `nav`: add whitespace to nav links, add hover effects to nav items
* `header`: remove duplicate nav styles, add whitespace
* `app`: add whitespace
* Adjust page name for conciseness ( I think it looks cleaner 😄 )
* Remove commented out imports, and unused imports

## Screenshots
![menu-styles](https://user-images.githubusercontent.com/17681528/86664486-5e940980-bfb4-11ea-8d5b-e02ffbce2c21.gif)


## Checklist
- [x] Looks good on desktop
- [x] Looks good on mobile